### PR TITLE
Changes in GrafanaDatastoreServer.py

### DIFF
--- a/tools/GrafanaDatastoreServer.py
+++ b/tools/GrafanaDatastoreServer.py
@@ -48,9 +48,10 @@ def query():
     for target in targets:
         args = ['ts.range', target, int(stime), int(etime)]
         if 'intervalMs' in request and request['intervalMs'] > 0 and request['intervalMs']/1000 > 1:
-            args += ['avg', request['intervalMs']/1000]
+            args += ['avg', int(round(request['intervalMs']/1000))]
+        print(args)
         redis_resp = redis_client.execute_command(*args)
-        datapoints = [(x2, x1*1000) for x1, x2 in redis_resp]
+        datapoints = [(x2.decode("ascii"), x1*1000) for x1, x2 in redis_resp]
         response.append(dict(target=target, datapoints=datapoints))
     return jsonify(response)
 


### PR DESCRIPTION
This commit fixes two problems I encountered while trying to integrate to Grafana (Python 3.5.3, Grafana 4.6.3):

## TSDB: time-delta must != 0

Redis responds with `TSDB: time-delta must != 0` if the `TS.RANGE` query is called with e.g. `avg 2.0`. The bucketSizeSeconds argument needs to be rounded before passing it to Redis.

```
[2017-12-21 16:14:51,392] ERROR in app: Exception on /query [POST]
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.5/dist-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.5/dist-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "GrafanaDatastoreServer.py", line 52, in query
    redis_resp = redis_client.execute_command(*args)
  File "/usr/local/lib/python3.5/dist-packages/redis/client.py", line 668, in execute_command
    return self.parse_response(connection, command_name, **options)
  File "/usr/local/lib/python3.5/dist-packages/redis/client.py", line 680, in parse_response
    response = connection.read_response()
  File "/usr/local/lib/python3.5/dist-packages/redis/connection.py", line 629, in read_response
    raise response
redis.exceptions.ResponseError: TSDB: time-delta must != 0
```

## TypeError: b'6' is not JSON serializable

The datapoint values are returned as byte arrays instead of string by the Redis python library. They should be decoded before passing to JSON serialization.